### PR TITLE
Website protocol url inconsistency.

### DIFF
--- a/_includes/team-list.html
+++ b/_includes/team-list.html
@@ -42,7 +42,12 @@
           {% endif %}
           <!-- website -->
           {% if team.website != "" %}
-          <a href="https://{{ team.website }}" target="_blank">
+            {% if team.website contains '://' %}
+              {% assign website = team.website %}
+            {% else %}
+              {% assign website = 'https://' | append: team.website %}
+            {% endif %}
+          <a href="{{ website }}" target="_blank">
             <img class="social-icon" src="/static/img/site/pwebsite.svg" alt="Email" />
           </a>
           {% endif %}


### PR DESCRIPTION
# Problem 

Some of the website field for the teams page is inconsistent, some of the data had a protocol while some didn't hence the link are unusable for non technical people that could identify the problem.

## Before

![Screenshot 2023-08-04 at 23 00 16](https://github.com/djangocon/2023.djangocon.africa/assets/18401062/c0b3141a-15ea-4404-8110-3174ecc6e124)


# Solution

Make a variable that can properly handle URL with or without a protocol

## After

![Screenshot 2023-08-04 at 23 01 24](https://github.com/djangocon/2023.djangocon.africa/assets/18401062/c9a19ccf-be6d-44f8-a636-5456ba727425)
